### PR TITLE
RI/JDJ/populate fan operating points

### DIFF
--- a/rpd_generator/bdl_structure/bdl_commands/system.py
+++ b/rpd_generator/bdl_structure/bdl_commands/system.py
@@ -68,6 +68,7 @@ BDL_ReturnAirPathOptions = BDLEnums.bdl_enums["SystemReturnAirPathOptions"]
 BDL_WLHPCategoryOptions = BDLEnums.bdl_enums["SystemWLHPCategoryOptions"]
 BDL_SystemCondenserTypes = BDLEnums.bdl_enums["SystemCondenserTypes"]
 BDL_CondenserKeywords = BDLEnums.bdl_enums["CondenserKeywords"]
+BDL_ZoneFanControlOptions = BDLEnums.bdl_enums["ZoneFanControlOptions"]
 
 
 class System(ParentNode):
@@ -1336,7 +1337,6 @@ class FanSystem:
 
 
 class Fan:
-
     fan_power_curves = {
         BDL_SystemFanControlOptions.SPEED: [
             0.00153028,
@@ -1365,8 +1365,8 @@ class Fan:
         BDL_SystemFanControlOptions.CYCLING: [0.0, 1.0, 0.0, 0.0],
     }
 
-    def __init__(self, parent_system=None):
-        self.parent_system = parent_system
+    def __init__(self, parent=None):
+        self.parent = parent
         self.data_structure = {}
 
         self.name = None
@@ -1418,51 +1418,58 @@ class Fan:
                 self.data_structure[attr] = value
 
     def populate_operating_points(self, fan_type):
-        if fan_type not in ["Supply", "Return", "Relief", "HeatingSupply"]:
+        if fan_type not in ["Supply", "Return", "Relief", "HeatingSupply", "Terminal"]:
             raise ValueError(
                 f"Invalid fan type: {fan_type}. Expected 'Supply', 'Return', 'Relief', or 'HeatingSupply'."
             )
 
         if fan_type == "Supply":
-            fan_control_method = self.parent_system.get_inp(
-                BDL_SystemKeywords.FAN_CONTROL
-            )
-            fan_placement = self.parent_system.get_inp(BDL_SystemKeywords.FAN_PLACEMENT)
+            fan_control_method = self.parent.get_inp(BDL_SystemKeywords.FAN_CONTROL)
+            fan_placement = self.parent.get_inp(BDL_SystemKeywords.FAN_PLACEMENT)
             if not fan_control_method == BDL_SystemFanControlOptions.FAN_EIR_FPLR:
                 curve_coeffs = self.fan_power_curves.get(fan_control_method)
             else:
-                curve = self.parent_system.get_obj(
-                    self.parent_system.get_inp(BDL_SystemKeywords.FAN_EIR_FPLR)
+                curve = self.parent.get_obj(
+                    self.parent.get_inp(BDL_SystemKeywords.FAN_EIR_FPLR)
                 )
                 curve_coeffs = curve.coefficients
 
+        elif fan_type == "Terminal":
+            fan_control_method = self.parent.get_inp(BDL_ZoneKeywords.ZONE_FAN_CTRL)
+            fan_placement = None
+            if fan_control_method == BDL_ZoneFanControlOptions.CONSTANT_VOLUME:
+                curve_coeffs = self.fan_power_curves.get(
+                    BDL_SystemFanControlOptions.CYCLING
+                )
+            elif fan_control_method == BDL_ZoneFanControlOptions.VARIABLE_VOLUME:
+                curve = self.parent.get_obj(
+                    self.parent.get_inp(BDL_ZoneKeywords.ZONE_FAN_KW_FPLR)
+                )
+                curve_coeffs = curve.coefficients
+            else:
+                curve_coeffs = None
+
         elif fan_type in ["Return", "Relief"]:
-            fan_control_method = self.parent_system.get_inp(
+            fan_control_method = self.parent.get_inp(
                 BDL_SystemKeywords.RETURN_FAN_CONTR
             )
-            fan_placement = self.parent_system.get_inp(
-                BDL_SystemKeywords.RETURN_FAN_LOC
-            )
+            fan_placement = self.parent.get_inp(BDL_SystemKeywords.RETURN_FAN_LOC)
             if not fan_control_method == BDL_SystemFanControlOptions.FAN_EIR_FPLR:
                 curve_coeffs = self.fan_power_curves.get(fan_control_method)
             else:
-                curve = self.parent_system.get_obj(
-                    self.parent_system.get_inp(BDL_SystemKeywords.RETURN_EIR_FPLR)
+                curve = self.parent.get_obj(
+                    self.parent.get_inp(BDL_SystemKeywords.RETURN_EIR_FPLR)
                 )
                 curve_coeffs = curve.coefficients
 
         else:  # fan_type == "HeatingSupply":
-            fan_control_method = self.parent_system.get_inp(
-                BDL_SystemKeywords.HFAN_CONTROL
-            )
-            fan_placement = self.parent_system.get_inp(
-                BDL_SystemKeywords.HFAN_PLACEMENT
-            )
+            fan_control_method = self.parent.get_inp(BDL_SystemKeywords.HFAN_CONTROL)
+            fan_placement = self.parent.get_inp(BDL_SystemKeywords.HFAN_PLACEMENT)
             if not fan_control_method == BDL_SystemFanControlOptions.FAN_EIR_FPLR:
                 curve_coeffs = self.fan_power_curves.get(fan_control_method)
             else:
-                curve = self.parent_system.get_obj(
-                    self.parent_system.get_inp(BDL_SystemKeywords.HFAN_EIR_FPLR)
+                curve = self.parent.get_obj(
+                    self.parent.get_inp(BDL_SystemKeywords.HFAN_EIR_FPLR)
                 )
                 curve_coeffs = curve.coefficients
 

--- a/rpd_generator/bdl_structure/bdl_commands/system.py
+++ b/rpd_generator/bdl_structure/bdl_commands/system.py
@@ -1,4 +1,5 @@
 from rpd_generator.bdl_structure.parent_node import ParentNode
+from rpd_generator.utilities.curve_funcs import calculate_cubic
 from rpd_generator.schema.schema_enums import SchemaEnums
 from rpd_generator.bdl_structure.bdl_enumerations.bdl_enums import BDLEnums
 
@@ -55,6 +56,7 @@ BDL_EnergyRecoveryTemperatureControlOptions = BDLEnums.bdl_enums[
 BDL_SystemMinimumOutdoorAirControlOptions = BDLEnums.bdl_enums[
     "SystemMinimumOutdoorAirControlOptions"
 ]
+BDL_FanPlacementOptions = BDLEnums.bdl_enums["SystemFanPlacementOptions"]
 BDL_IndoorFanModeOptions = BDLEnums.bdl_enums["SystemIndoorFanModeOptions"]
 BDL_HumidificationOptions = BDLEnums.bdl_enums["SystemHumidificationOptions"]
 BDL_DualDuctFanOptions = BDLEnums.bdl_enums["SystemDualDuctFanOptions"]
@@ -791,6 +793,8 @@ class System(ParentNode):
             self.supply_fan.total_efficiency = (
                 self.supply_fan.motor_efficiency * supply_mech_eff
             )
+        if not self.fan_system.fan_control == FanSystemSupplyFanControlOptions.CONSTANT:
+            self.supply_fan.populate_operating_points("Supply")
 
         self.supply_fan.populate_data_group()
 
@@ -837,6 +841,11 @@ class System(ParentNode):
                 self.relief_fan.total_efficiency = (
                     self.relief_fan.motor_efficiency * return_mech_eff
                 )
+            if (
+                not self.fan_system.fan_control
+                == FanSystemSupplyFanControlOptions.CONSTANT
+            ):
+                self.supply_fan.populate_operating_points("Relief")
 
             self.relief_fan.populate_data_group()
 
@@ -875,6 +884,11 @@ class System(ParentNode):
                 self.return_fan.total_efficiency = (
                     self.return_fan.motor_efficiency * return_mech_eff
                 )
+            if (
+                not self.fan_system.fan_control
+                == FanSystemSupplyFanControlOptions.CONSTANT
+            ):
+                self.supply_fan.populate_operating_points("Return")
 
             self.return_fan.populate_data_group()
 
@@ -919,6 +933,11 @@ class System(ParentNode):
                 self.heating_supply_fan.total_efficiency = (
                     self.heating_supply_fan.motor_efficiency * hsupply_mech_eff
                 )
+            if (
+                not self.fan_system.fan_control
+                == FanSystemSupplyFanControlOptions.CONSTANT
+            ):
+                self.supply_fan.populate_operating_points("HeatingSupply")
 
             self.heating_supply_fan.populate_data_group()
 
@@ -1318,6 +1337,34 @@ class FanSystem:
 
 class Fan:
 
+    fan_power_curves = {
+        BDL_SystemFanControlOptions.SPEED: [
+            0.00153028,
+            0.00520806,
+            1.1086242,
+            -0.11635563,
+        ],
+        BDL_SystemFanControlOptions.INLET: [
+            0.35071223,
+            0.30805350,
+            -0.5413736,
+            0.87198823,
+        ],
+        BDL_SystemFanControlOptions.DISCHARGE: [
+            0.37073425,
+            0.97250253,
+            -0.3424076,
+            0.0,
+        ],
+        BDL_SystemFanControlOptions.DEFAULT_FAN_CTRL: [
+            0.37073425,
+            0.97250253,
+            -0.3424076,
+            0.0,
+        ],
+        BDL_SystemFanControlOptions.CYCLING: [0.0, 1.0, 0.0, 0.0],
+    }
+
     def __init__(self, parent_system):
         self.parent_system = parent_system
         self.data_structure = {}
@@ -1344,6 +1391,9 @@ class Fan:
     def populate_data_group(self):
         self.data_structure["id"] = self.name
 
+        if self.operating_points:
+            self.data_structure["operating_points"] = self.operating_points
+
         fan_data_elements = [
             "reporting_name",
             "notes",
@@ -1367,15 +1417,72 @@ class Fan:
             if value is not None:
                 self.data_structure[attr] = value
 
-    # def insert_to_rpd(self, fan_type):
-    #     if fan_type == "Supply":
-    #         self.parent_system.fan_system.supply_fans.append(self.data_structure)
-    #     elif fan_type == "Return":
-    #         self.parent_system.fan_system.return_fans.append(self.data_structure)
-    #     elif fan_type == "Relief":
-    #         self.parent_system.fan_system.relief_fans.append(self.data_structure)
-    #     elif fan_type == "HeatingSupply":
-    #         self.parent_system.fan_system.supply_fans.append(self.data_structure)
+    def populate_operating_points(self, fan_type):
+        if fan_type not in ["Supply", "Return", "HeatingSupply"]:
+            raise ValueError(
+                f"Invalid fan type: {fan_type}. Expected 'Supply', 'Return', or 'HeatingSupply'."
+            )
+
+        if fan_type == "Supply":
+            fan_control_method = self.parent_system.get_inp(
+                BDL_SystemKeywords.FAN_CONTROL
+            )
+            fan_placement = self.parent_system.get_inp(BDL_SystemKeywords.FAN_PLACEMENT)
+            if not fan_control_method == BDL_SystemFanControlOptions.FAN_EIR_FPLR:
+                curve_coeffs = self.fan_power_curves.get(fan_control_method)
+            else:
+                curve = self.parent_system.get_obj(
+                    self.parent_system.get_inp(BDL_SystemKeywords.FAN_EIR_FPLR)
+                )
+                curve_coeffs = curve.coefficients
+
+        elif fan_type == "Return":
+            fan_control_method = self.parent_system.get_inp(
+                BDL_SystemKeywords.RETURN_FAN_CONTR
+            )
+            fan_placement = self.parent_system.get_inp(
+                BDL_SystemKeywords.RETURN_FAN_LOC
+            )
+            if not fan_control_method == BDL_SystemFanControlOptions.FAN_EIR_FPLR:
+                curve_coeffs = self.fan_power_curves.get(fan_control_method)
+            else:
+                curve = self.parent_system.get_obj(
+                    self.parent_system.get_inp(BDL_SystemKeywords.RETURN_EIR_FPLR)
+                )
+                curve_coeffs = curve.coefficients
+
+        else:  # fan_type == "HeatingSupply":
+            fan_control_method = self.parent_system.get_inp(
+                BDL_SystemKeywords.HFAN_CONTROL
+            )
+            fan_placement = self.parent_system.get_inp(
+                BDL_SystemKeywords.HFAN_PLACEMENT
+            )
+            if not fan_control_method == BDL_SystemFanControlOptions.FAN_EIR_FPLR:
+                curve_coeffs = self.fan_power_curves.get(fan_control_method)
+            else:
+                curve = self.parent_system.get_obj(
+                    self.parent_system.get_inp(BDL_SystemKeywords.HFAN_EIR_FPLR)
+                )
+                curve_coeffs = curve.coefficients
+
+        if curve_coeffs:
+            multiplier = (
+                1.11 if fan_placement == BDL_FanPlacementOptions.BLOW_THROUGH else 1.0
+            )
+            for i in range(0, 110, 10):
+                airflow_ratio = i / 100
+                electric_input_ratio = calculate_cubic(
+                    curve_coeffs, airflow_ratio, 0, 1
+                )
+                self.operating_points.append(
+                    {
+                        "airflow": self.design_airflow * airflow_ratio,
+                        "power": self.design_electric_power
+                        * electric_input_ratio
+                        * multiplier,
+                    }
+                )
 
 
 class HeatingSystem:

--- a/rpd_generator/bdl_structure/bdl_commands/system.py
+++ b/rpd_generator/bdl_structure/bdl_commands/system.py
@@ -1038,6 +1038,9 @@ class FanSystem:
             self.parent_system.get_inp(BDL_SystemKeywords.FAN_CONTROL)
         )
         self.temperature_control = self.get_temperature_control()
+        self.operating_schedule = self.parent_system.get_inp(
+            BDL_SystemKeywords.FAN_SCHEDULE
+        )
         self.demand_control_ventilation_control = self.dcv_map.get(
             self.parent_system.get_inp(BDL_SystemKeywords.MIN_OA_METHOD)
         )
@@ -1418,9 +1421,9 @@ class Fan:
                 self.data_structure[attr] = value
 
     def populate_operating_points(self, fan_type):
-        if fan_type not in ["Supply", "Return", "HeatingSupply"]:
+        if fan_type not in ["Supply", "Return", "Relief", "HeatingSupply"]:
             raise ValueError(
-                f"Invalid fan type: {fan_type}. Expected 'Supply', 'Return', or 'HeatingSupply'."
+                f"Invalid fan type: {fan_type}. Expected 'Supply', 'Return', 'Relief', or 'HeatingSupply'."
             )
 
         if fan_type == "Supply":
@@ -1436,7 +1439,7 @@ class Fan:
                 )
                 curve_coeffs = curve.coefficients
 
-        elif fan_type == "Return":
+        elif fan_type in ["Return", "Relief"]:
             fan_control_method = self.parent_system.get_inp(
                 BDL_SystemKeywords.RETURN_FAN_CONTR
             )

--- a/rpd_generator/bdl_structure/bdl_commands/system.py
+++ b/rpd_generator/bdl_structure/bdl_commands/system.py
@@ -845,7 +845,7 @@ class System(ParentNode):
                 not self.fan_system.fan_control
                 == FanSystemSupplyFanControlOptions.CONSTANT
             ):
-                self.supply_fan.populate_operating_points("Relief")
+                self.relief_fan.populate_operating_points("Relief")
 
             self.relief_fan.populate_data_group()
 
@@ -888,7 +888,7 @@ class System(ParentNode):
                 not self.fan_system.fan_control
                 == FanSystemSupplyFanControlOptions.CONSTANT
             ):
-                self.supply_fan.populate_operating_points("Return")
+                self.return_fan.populate_operating_points("Return")
 
             self.return_fan.populate_data_group()
 
@@ -937,7 +937,7 @@ class System(ParentNode):
                 not self.fan_system.fan_control
                 == FanSystemSupplyFanControlOptions.CONSTANT
             ):
-                self.supply_fan.populate_operating_points("HeatingSupply")
+                self.heating_supply_fan.populate_operating_points("HeatingSupply")
 
             self.heating_supply_fan.populate_data_group()
 

--- a/rpd_generator/bdl_structure/bdl_commands/zone.py
+++ b/rpd_generator/bdl_structure/bdl_commands/zone.py
@@ -972,7 +972,7 @@ class Terminal:
             )
 
             if self.zone.parent.is_terminal:
-                self.zone.terminal_fan = Fan()
+                self.zone.terminal_fan = Fan(self.zone)
                 self.zone.terminal_fan.name = self.zone.u_name + " MainTerminal Fan"
                 self.zone.terminal_fan.specification_method = (
                     FanSpecificationMethodOptions.DETAILED
@@ -1012,6 +1012,9 @@ class Terminal:
                             or self.zone.get_inp(BDL_ZoneKeywords.HMIN_FLOW_AREA)
                         )
                     )
+
+                if self.type == TerminalOptions.VARIABLE_AIR_VOLUME:
+                    self.zone.terminal_fan.populate_operating_points("Supply")
 
                 self.heating_capacity = self.zone.try_abs(
                     self.zone.try_float(
@@ -1074,6 +1077,8 @@ class Terminal:
                     self.zone.terminal_fan.design_electric_power = output_data.get(
                         "Supply Fan - Power"
                     )
+
+                self.zone.terminal_fan.populate_data_group()
 
             else:  # not self.parent.is_terminal:
                 if self.zone.parent.is_zonal_system:
@@ -1164,6 +1169,7 @@ class Terminal:
                     BDL_TerminalTypes.SERIES_PIU,
                     BDL_TerminalTypes.PARALLEL_PIU,
                 ]:
+                    self.zone.terminal_fan = Fan(self.zone)
                     self.zone.terminal_fan.name = self.zone.u_name + " MainTerminal Fan"
                     self.zone.terminal_fan.design_airflow = piu_fan_flow
                     self.is_fan_first_stage_heat = self.is_fan_first_stage_map.get(
@@ -1184,6 +1190,11 @@ class Terminal:
                         self.fan_configuration
                         or TerminalFanConfigurationOptions.PARALLEL
                     )
+
+                    if self.type == TerminalOptions.VARIABLE_AIR_VOLUME:
+                        self.zone.terminal_fan.populate_operating_points("Terminal")
+
+                    self.zone.terminal_fan.populate_data_group()
 
             elif self.zone.get_inp(BDL_ZoneKeywords.TERMINAL_TYPE) in [
                 BDL_TerminalTypes.DUAL_DUCT,
@@ -1271,6 +1282,9 @@ class Terminal:
 
     def populate_data_group(self):
         self.data_structure["id"] = self.name
+
+        if self.zone.terminal_fan:
+            self.fan = self.zone.terminal_fan.data_structure
 
         terminal_data_elements = [
             "reporting_name",

--- a/rpd_generator/bdl_structure/bdl_enumerations/bdl_enums.py
+++ b/rpd_generator/bdl_structure/bdl_enumerations/bdl_enums.py
@@ -806,6 +806,7 @@ class BDLEnums:
                 "TWO-SPEED",
                 "CONSTANT-VOLUME",
                 "FAN-EIR-FPLR",
+                "DEFAULT-FAN-CTRL",
             ]
         ),
         "SystemNightCycleControlOptions": _ListEnum(
@@ -918,6 +919,12 @@ class BDLEnums:
                 "GROUND-LOOP",
             ]
         ),
+        "SystemFanPlacementOptions": _ListEnum(
+            [
+                "BLOW-THROUGH",
+                "DRAW-THROUGH",
+            ]
+        ),
         "SystemKeywords": _ListEnum(
             [
                 "TYPE",
@@ -954,6 +961,7 @@ class BDLEnums:
                 "DDS-TYPE",
                 "FAN-CONTROL",
                 "FAN-SCHEDULE",
+                "FAN-PLACEMENT",
                 "INDOOR-FAN-MODE",
                 "NIGHT-CYCLE-CTRL",
                 "MIN-OA-METHOD",
@@ -989,21 +997,28 @@ class BDLEnums:
                 "DES-MIN-SST",
                 "DES-MAX-SST",
                 "SUPPLY-FLOW",
+                "SUPPLY-KW/FLOW",
                 "SUPPLY-STATIC",
                 "SUPPLY-MTR-EFF",
                 "SUPPLY-MECH-EFF",
+                "FAN-EIR-FPLR",
                 "RETURN-FLOW",
                 "RETURN-STATIC",
                 "RETURN-MTR-EFF",
                 "RETURN-MECH-EFF",
                 "RETURN-AIR-PATH",
                 "RETURN-KW/FLOW",
+                "RETURN-EIR-FPLR",
                 "RETURN-FAN-LOC",
+                "RETURN-FAN-CONTR",
                 "HSUPPLY-FLOW",
                 "HSUPPLY-STATIC",
                 "HSUPPLY-MTR-EFF",
                 "HSUPPLY-MECH-EFF",
                 "HSUPPLY-KW/FLOW",
+                "HFAN-EIR-FPLR",
+                "HFAN-CONTROL",
+                "HFAN-PLACEMENT",
                 "OA-CONTROL",
                 "DOA-SYSTEM",
                 "DOAS-ATTACHED-TO",

--- a/rpd_generator/bdl_structure/bdl_enumerations/bdl_enums.py
+++ b/rpd_generator/bdl_structure/bdl_enumerations/bdl_enums.py
@@ -1235,6 +1235,7 @@ class BDLEnums:
                 "ZONE-FAN-FLOW",
                 "ZONE-FAN-CTRL",
                 "ZONE-FAN-RUN",
+                "ZONE-FAN-KW-FPLR",
                 "CHW-LOOP",
                 "CW-LOOP",
                 "WSE-LOOP",

--- a/rpd_generator/schema/ASHRAE229.schema.json
+++ b/rpd_generator/schema/ASHRAE229.schema.json
@@ -955,10 +955,6 @@
                         }
                     ]
                 },
-                "surface_construction_input_option": {
-                    "description": "Identifies whether construction is entered layer-by-layer or simplified (R-value)",
-                    "$ref": "ASHRAE229.schema.json#/definitions/SurfaceConstructionInputOptions"
-                },
                 "fraction_framing": {
                     "description": "Fraction of the construction that is framing.",
                     "type": "number",
@@ -3001,7 +2997,7 @@
                     "description": "Energy validation points",
                     "type": "array",
                     "items": {
-                        "$ref": "ASHRAE229.schema.json#/definitions/FanOutputValidationPoint"
+                        "$ref": "ASHRAE229.schema.json#/definitions/FanOperatingPoint"
                     },
                     "notes": "Airflow is input to each validation point and energy output is the result. A minimum number of four points is recommended. Certain rulesets may have a different minimum number of points. For example, 90.1 Appendix G expects 11 data points."
                 }
@@ -3011,7 +3007,7 @@
             ],
             "additionalProperties": false
         },
-        "FanOutputValidationPoint": {
+        "FanOperatingPoint": {
             "type": "object",
             "properties": {
                 "airflow": {
@@ -4588,10 +4584,6 @@
                     "description": "Indicates whether the water heater has electrical ignition",
                     "type": "boolean",
                     "notes": "From CBECC-Com."
-                },
-                "heater_type": {
-                    "description": "Service water heater type",
-                    "$ref": "ASHRAE229.schema.json#/definitions/ServiceWaterHeaterOptions"
                 },
                 "tank": {
                     "description": "Tank that is part of the service water heating equipment",

--- a/rpd_generator/schema/resources/item_parents.json
+++ b/rpd_generator/schema/resources/item_parents.json
@@ -121,8 +121,8 @@
     "AirEnergyRecovery": [
         "air_energy_recovery"
     ],
-    "FanOutputValidationPoint": [
-        "output_validation_points"
+    "FanOperatingPoint": [
+        "operating_points"
     ],
     "FluidLoopDesignAndControl": [
         "cooling_or_condensing_design_and_control",

--- a/rpd_generator/schema/resources/schema_units.json
+++ b/rpd_generator/schema/resources/schema_units.json
@@ -114,9 +114,9 @@
         "motor_nameplate_power": "W",
         "shaft_power": "W"
     },
-    "FanOutputValidationPoint": {
+    "FanOperatingPoint": {
         "airflow": "L/s",
-        "result": "W"
+        "power": "W"
     },
     "Terminal": {
         "primary_airflow": "L/s",

--- a/rpd_generator/utilities/curve_funcs.py
+++ b/rpd_generator/utilities/curve_funcs.py
@@ -123,12 +123,10 @@ def calculate_cubic(
     Returns:
         float: The computed `Z` value, constrained within `[min_val, max_val]`.
     """
-    z = (
-        curve_coeffs[0]
-        + curve_coeffs[1] * x
-        + curve_coeffs[2] * x**2
-        + curve_coeffs[3] * x**3
-    )
+    # Extend the list with zeros if it has fewer than 4 coefficients
+    coeffs = curve_coeffs + [0.0] * (4 - len(curve_coeffs))
+
+    z = coeffs[0] + coeffs[1] * x + coeffs[2] * x**2 + coeffs[3] * x**3
 
     # Ensure z is within the range [min_val, max_val]
     z = max(min_val, min(z, max_val))

--- a/rpd_generator/utilities/resources/equest_units.json
+++ b/rpd_generator/utilities/resources/equest_units.json
@@ -114,9 +114,9 @@
         "motor_nameplate_power": "",
         "shaft_power": ""
     },
-    "FanOutputValidationPoint": {
-        "airflow": "",
-        "result": ""
+    "FanOperatingPoint": {
+        "airflow": "cfm",
+        "power": "kW"
     },
     "Terminal": {
         "primary_airflow": "cfm",

--- a/rpd_generator/utilities/resources/manual_item_json_paths.json
+++ b/rpd_generator/utilities/resources/manual_item_json_paths.json
@@ -127,12 +127,12 @@
     "AirEnergyRecovery": [
         "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.air_energy_recovery"
     ],
-    "FanOutputValidationPoint": [
-        "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].zones[*].zonal_exhaust_fan.output_validation_points",
-        "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.supply_fans[*].output_validation_points",
-        "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.return_fans[*].output_validation_points",
-        "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.exhaust_fans[*].output_validation_points",
-        "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.relief_fans[*].output_validation_points"
+    "FanOperatingPoint": [
+        "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].zones[*].zonal_exhaust_fan.operating_points",
+        "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.supply_fans[*].operating_points",
+        "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.return_fans[*].operating_points",
+        "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.exhaust_fans[*].operating_points",
+        "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.relief_fans[*].operating_points"
     ],
     "FluidLoopDesignAndControl": [
         "$.ruleset_model_descriptions[*].fluid_loops[*].cooling_or_condensing_design_and_control",

--- a/rpd_generator/utilities/resources/manual_item_json_paths.json
+++ b/rpd_generator/utilities/resources/manual_item_json_paths.json
@@ -129,6 +129,7 @@
     ],
     "FanOperatingPoint": [
         "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].zones[*].zonal_exhaust_fan.operating_points",
+        "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].zones[*].terminals[*].fan.operating_points",
         "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.supply_fans[*].operating_points",
         "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.return_fans[*].operating_points",
         "$.ruleset_model_descriptions[*].buildings[*].building_segments[*].heating_ventilating_air_conditioning_systems[*].fan_system.exhaust_fans[*].operating_points",

--- a/test/populate_test/bdl_commands_test/system_test.py
+++ b/test/populate_test/bdl_commands_test/system_test.py
@@ -130,6 +130,8 @@ class TestSystems(unittest.TestCase):
             BDL_SystemKeywords.ERV_OA_FLOW: "5000",
             BDL_SystemKeywords.ERV_EXH_FLOW: "5500",
             BDL_SystemKeywords.FAN_SCHEDULE: "Fan Annual Schedule",
+            BDL_SystemKeywords.FAN_CONTROL: BDL_SystemFanControlOptions.DISCHARGE,
+            BDL_SystemKeywords.RETURN_FAN_CONTR: BDL_SystemFanControlOptions.DISCHARGE,
             BDL_SystemKeywords.PREHEAT_CAPACITY: "-48000",
             BDL_SystemKeywords.PREHEAT_T: "60",
             BDL_SystemKeywords.COOL_CONTROL: BDL_CoolControlOptions.WARMEST,
@@ -181,6 +183,7 @@ class TestSystems(unittest.TestCase):
                 },
                 "has_fully_ducted_return": False,
                 "maximum_outdoor_airflow": 12,
+                "operating_schedule": "Fan Annual Schedule",
                 "operation_during_occupied": "CONTINUOUS",
                 "operation_during_unoccupied": "CYCLING",
                 "return_fans": [
@@ -193,6 +196,19 @@ class TestSystems(unittest.TestCase):
                         "motor_efficiency": 0.7,
                         "specification_method": "DETAILED",
                         "total_efficiency": 0.5599999999999999,
+                        "operating_points": [
+                            {"airflow": 0.0, "power": 4.07807675},
+                            {"airflow": 1.0, "power": 5.110164697},
+                            {"airflow": 2.0, "power": 6.0669229719999995},
+                            {"airflow": 3.0, "power": 6.948351574999999},
+                            {"airflow": 4.0, "power": 7.7544505059999995},
+                            {"airflow": 5.0, "power": 8.485219765},
+                            {"airflow": 6.0, "power": 9.140659352},
+                            {"airflow": 7.0, "power": 9.720769267},
+                            {"airflow": 8.0, "power": 10.22554951},
+                            {"airflow": 9.0, "power": 10.655000080999999},
+                            {"airflow": 10.0, "power": 11.0},
+                        ],
                     }
                 ],
                 "supply_fans": [
@@ -205,9 +221,23 @@ class TestSystems(unittest.TestCase):
                         "motor_efficiency": 0.9,
                         "specification_method": "DETAILED",
                         "total_efficiency": 0.855,
+                        "operating_points": [
+                            {"airflow": 0.0, "power": 4.81954525},
+                            {"airflow": 1.2000000000000002, "power": 6.039285551},
+                            {"airflow": 2.4000000000000004, "power": 7.169999875999999},
+                            {"airflow": 3.5999999999999996, "power": 8.211688225},
+                            {"airflow": 4.800000000000001, "power": 9.164350598},
+                            {"airflow": 6.0, "power": 10.027986995},
+                            {"airflow": 7.199999999999999, "power": 10.802597416000001},
+                            {"airflow": 8.399999999999999, "power": 11.488181861},
+                            {"airflow": 9.600000000000001, "power": 12.08474033},
+                            {"airflow": 10.8, "power": 12.592272822999998},
+                            {"airflow": 12.0, "power": 13.0},
+                        ],
                     }
                 ],
                 "temperature_control": "ZONE_RESET",
+                "fan_control": "DISCHARGE_DAMPER",
             },
             "preheat_system": {
                 "id": "System 1 PreheatSys",
@@ -260,6 +290,7 @@ class TestSystems(unittest.TestCase):
             BDL_SystemKeywords.ERV_SENSIBLE_EFF: "0.7",
             BDL_SystemKeywords.ERV_LATENT_EFF: "0.6",
             BDL_SystemKeywords.FAN_SCHEDULE: "Fan Annual Schedule",
+            BDL_SystemKeywords.FAN_CONTROL: BDL_SystemFanControlOptions.SPEED,
             BDL_SystemKeywords.COOL_CONTROL: BDL_CoolControlOptions.CONSTANT,
             BDL_SystemKeywords.HEAT_CONTROL: BDL_HeatControlOptions.CONSTANT,
             BDL_SystemKeywords.HEAT_SET_T: "75",
@@ -309,6 +340,7 @@ class TestSystems(unittest.TestCase):
                 },
                 "has_fully_ducted_return": False,
                 "maximum_outdoor_airflow": 12,
+                "operating_schedule": "Fan Annual Schedule",
                 "operation_during_occupied": "CONTINUOUS",
                 "operation_during_unoccupied": "CYCLING",
                 "relief_fans": [
@@ -333,9 +365,29 @@ class TestSystems(unittest.TestCase):
                         "motor_efficiency": 0.9,
                         "specification_method": "DETAILED",
                         "total_efficiency": 0.855,
+                        "operating_points": [
+                            {"airflow": 0.0, "power": 0.01989364},
+                            {
+                                "airflow": 1.2000000000000002,
+                                "power": 0.16927264080999999,
+                            },
+                            {
+                                "airflow": 2.4000000000000004,
+                                "power": 0.5978181944800001,
+                            },
+                            {"airflow": 3.5999999999999996, "power": 1.29645456187},
+                            {"airflow": 4.800000000000001, "power": 2.2561060038400003},
+                            {"airflow": 6.0, "power": 3.467696781249999},
+                            {"airflow": 7.199999999999999, "power": 4.92215115496},
+                            {"airflow": 8.399999999999999, "power": 6.610393385829998},
+                            {"airflow": 9.600000000000001, "power": 8.523347734720002},
+                            {"airflow": 10.8, "power": 10.65193846249},
+                            {"airflow": 12.0, "power": 12.98708983},
+                        ],
                     }
                 ],
                 "temperature_control": "CONSTANT",
+                "fan_control": "VARIABLE_SPEED_DRIVE",
             },
             "heating_system": {
                 "id": "System 1 HeatSys",
@@ -402,6 +454,7 @@ class TestSystems(unittest.TestCase):
                 },
                 "has_fully_ducted_return": False,
                 "maximum_outdoor_airflow": 12,
+                "operating_schedule": "Fan Annual Schedule",
                 "operation_during_occupied": "CYCLING",
                 "operation_during_unoccupied": "CYCLING",
                 "supply_fans": [
@@ -463,6 +516,7 @@ class TestSystems(unittest.TestCase):
                 "id": "System 1 FanSys",
                 "has_fully_ducted_return": False,
                 "operation_during_occupied": "CONTINUOUS",
+                "operating_schedule": "Fan Annual Schedule",
                 "supply_fans": [
                     {
                         "id": "System 1 SupplyFan",
@@ -500,6 +554,7 @@ class TestSystems(unittest.TestCase):
                 "id": "System 1 FanSys",
                 "has_fully_ducted_return": False,
                 "operation_during_occupied": "KEEP_OFF",
+                "operating_schedule": "Fan Annual Schedule",
                 "supply_fans": [
                     {
                         "id": "System 1 SupplyFan",
@@ -578,6 +633,7 @@ class TestSystems(unittest.TestCase):
                 },
                 "has_fully_ducted_return": False,
                 "maximum_outdoor_airflow": 12,
+                "operating_schedule": "Fan Annual Schedule",
                 "operation_during_occupied": "CONTINUOUS",
                 "operation_during_unoccupied": "CONTINUOUS",
                 "supply_fans": [

--- a/test/populate_test/bdl_commands_test/zone_test.py
+++ b/test/populate_test/bdl_commands_test/zone_test.py
@@ -373,6 +373,16 @@ class TestZones(unittest.TestCase):
                     "supply_design_cooling_setpoint_temperature": 50.0,
                     "supply_design_heating_setpoint_temperature": 70.0,
                     "temperature_control": "CONSTANT",
+                    "fan": {
+                        "design_airflow": 10000,
+                        "design_electric_power": 0,
+                        "design_pressure_rise": 30.0,
+                        "id": "Zone 1 MainTerminal Fan",
+                        "is_airflow_sized_based_on_design_day": False,
+                        "motor_efficiency": 0.9,
+                        "specification_method": "DETAILED",
+                        "total_efficiency": 0.9,
+                    },
                 }
             ],
             "thermostat_cooling_setpoint_schedule": "Thermostat Annual Schedule",


### PR DESCRIPTION
One part of this implementation I am unsure about:


![image](https://github.com/user-attachments/assets/f1aed8a0-0f69-437f-9f63-fa37693c45ee)

However, there is the RETURN-FAN-CONTR keyword that presumably would allow a different fan control method to be selected. I have not gone so far to create a model with edge case scenarios like this.